### PR TITLE
Establish starry-10.3.8.0-20181031 and enable 1x1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.o
+*.cmd
+*.ko
+
+.tmp_versions
+
+modules.order
+Module.symvers
+mwlwifi.mod.c

--- a/core.c
+++ b/core.c
@@ -231,14 +231,18 @@ static void mwl_process_of_dts(struct mwl_priv *priv)
 			priv->disable_5g = true;
 		if (strcmp(prop->name, "marvell,chainmask") == 0) {
 			prop_value = be32_to_cpu(*((__be32 *)prop->value));
-			if (prop_value == 2)
+			if (prop_value == 1)
+				priv->antenna_tx = ANTENNA_TX_1;
+			else if (prop_value == 2)
 				priv->antenna_tx = ANTENNA_TX_2;
 			else if (prop_value == 3)
 				priv->antenna_tx = ANTENNA_TX_3;
 
 			prop_value = be32_to_cpu(*((__be32 *)
 						 (prop->value + 4)));
-			if (prop_value == 2)
+			if (prop_value == 1)
+				priv->antenna_rx = ANTENNA_RX_1;
+			else if (prop_value == 2)
 				priv->antenna_rx = ANTENNA_RX_2;
 			else if (prop_value == 3)
 				priv->antenna_rx = ANTENNA_RX_3;
@@ -1058,11 +1062,15 @@ int mwl_init_hw(struct ieee80211_hw *hw, const char *fw_name,
 		   priv->disable_2g ? "disabled" : "enabled",
 		   priv->disable_5g ? "disabled" : "enabled");
 
-	if (priv->antenna_tx == ANTENNA_TX_2)
+	if (priv->antenna_tx == ANTENNA_TX_1)
+		tx_num = 1;
+	else if (priv->antenna_tx == ANTENNA_TX_2)
 		tx_num = 2;
 	else if (priv->antenna_tx == ANTENNA_TX_3)
 		tx_num = 3;
-	if (priv->antenna_rx == ANTENNA_RX_2)
+	if (priv->antenna_rx == ANTENNA_RX_1)
+		rx_num = 1;
+	else if (priv->antenna_rx == ANTENNA_RX_2)
 		rx_num = 2;
 	else if (priv->antenna_rx == ANTENNA_RX_3)
 		rx_num = 3;

--- a/debugfs.c
+++ b/debugfs.c
@@ -363,10 +363,14 @@ static ssize_t mwl_debugfs_info_read(struct file *file, char __user *ubuf,
 			 "2g: %s\n", priv->disable_2g ? "disable" : "enable");
 	len += scnprintf(p + len, size - len,
 			 "5g: %s\n", priv->disable_5g ? "disable" : "enable");
-	if (priv->antenna_tx == ANTENNA_TX_2)
+	if (priv->antenna_tx == ANTENNA_TX_1)
+		tx_num = 1;
+	else if (priv->antenna_tx == ANTENNA_TX_2)
 		tx_num = 2;
 	else if (priv->antenna_tx == ANTENNA_TX_3)
 		tx_num = 3;
+	if (priv->antenna_rx == ANTENNA_RX_1)
+		rx_num = 1;
 	if (priv->antenna_rx == ANTENNA_RX_2)
 		rx_num = 2;
 	else if (priv->antenna_rx == ANTENNA_RX_3)

--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -37,6 +37,14 @@
 #define CHECK_BA_TRAFFIC_TIME           300 /* msec */
 #define CHECK_TX_DONE_TIME              50  /* msec */
 
+/* Optionally support the 8964 based on a module parameter. This allows for
+ * coexistence with the proprietary 8964 driver (wlan-v9).
+ */
+static int mwl_8964_support = 0;
+
+module_param(mwl_8964_support, int, 0);
+MODULE_PARM_DESC(mwl_8964_support, "Enable support for 88W8964");
+
 static struct pci_device_id pcie_id_tbl[] = {
 	{ PCI_VDEVICE(MARVELL, 0x2a55),     .driver_data = MWL8864, },
 	{ PCI_VDEVICE(MARVELL, 0x2b38),     .driver_data = MWL8897, },
@@ -1527,6 +1535,10 @@ static int pcie_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	if (id->driver_data >= MWLUNKNOWN)
 		return -ENODEV;
+
+	if ((id->driver_data == MWL8964) && (mwl_8964_support == 0)) {
+		return -ENOTSUPP;
+	}
 
 	if (!printed_version) {
 		pr_info("<<%s version %s>>\n",

--- a/hif/pcie/rx_ndp.c
+++ b/hif/pcie/rx_ndp.c
@@ -322,7 +322,9 @@ static inline void pcie_rx_process_fast_data(struct mwl_priv *priv,
 	} else
 		memcpy(skb_push(skb, hdrlen), &hdr, hdrlen);
 
+#if (defined(LINUX_BACKPORT) || (LINUX_VERSION_CODE >=KERNEL_VERSION(4,6,0)))
 	status->flag |= RX_FLAG_DUP_VALIDATED;
+#endif
 	ieee80211_rx(priv->hw, skb);
 
 	return;
@@ -382,7 +384,9 @@ static inline void pcie_rx_process_slow_data(struct mwl_priv *priv,
 		}
 	}
 
+#if (defined(LINUX_BACKPORT) || (LINUX_VERSION_CODE >=KERNEL_VERSION(4,6,0)))
 	status->flag |= RX_FLAG_DUP_VALIDATED;
+#endif
 	ieee80211_rx(priv->hw, skb);
 }
 


### PR DESCRIPTION
This carries-over (cherry-picks) local commits and enables 1x1 mode